### PR TITLE
fix: return valid JSON string from get_fields

### DIFF
--- a/include/falcosecurity_plugin.h
+++ b/include/falcosecurity_plugin.h
@@ -43,7 +43,7 @@ std::ostream& operator<< (std::ostream &os, plugin_field const &f)
 	os << "\"type\":\"" << (f.ftype == FTYPE_UINT64 ? "uint64" : "string") << "\",";
 	os << "\"name\":\"" << f.name << "\",";
 	os << "\"argRequired\":" << std::boolalpha << f.arg_required << ",";
-	os << "\"desc\":\"" << f.description << "\"";
+	os << "\"desc\":\"" << f.description << "\",";
 	os << "\"properties\":[";
 
 	bool first = true;


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

This fixes the JSON formatting of `get_fields`, which returned broken JSONs and prevented every C++ plugin based on this SDK to get rejected by the plugin framework 😸 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
