### PR TITLE
docs(README.md): add scope and status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Plugin SDK C++
 
-Status: **Experimental**
+[![Falco Ecosystem Repository](https://github.com/falcosecurity/evolution/blob/main/repos/badges/falco-ecosystem-blue.svg)](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#ecosystem-scope) [![Sandbox](https://img.shields.io/badge/status-sandbox-red?style=for-the-badge)](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#sandbox)
 
-Note: *The plugin system is a new feature and is still under active development. You can find more detail in the original [proposal document](https://github.com/falcosecurity/falco/blob/master/proposals/20210501-plugin-system.md) and the [official documentation](https://falco.org/docs/plugins/). Since this feature has not yet been released in Falco, consider it as experimental at the moment.*
+Note: This project is **experimental**.
 
 C++ header only library fo facilitate writing [Falcosecurity plugins](https://falco.org/docs/plugins/). Before using this library, review the [developer's guide](https://falco.org/docs/plugins/developers_guide/) and the [plugin API reference](https://falco.org/docs/plugins/plugin-api-reference/).
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR introduces the [scope](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#scope) and [status](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#status) badges. See https://github.com/falcosecurity/evolution/issues/271 for more details.

Fixes #

**Special notes for your reviewer**:

While adding the badges, I've noticed this repo does not match the criteria for the _incubating_ status, so I've added the badge for the sandbox.  I'll update its status on the evolution repository soon.

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
