### PR TITLE
Prevent inttypes.h from being wrapped in namespace

### DIFF
--- a/include/falcosecurity/internal/deps.h
+++ b/include/falcosecurity/internal/deps.h
@@ -19,6 +19,8 @@ limitations under the License.
 
 #include <falcosecurity/internal/deps/nlohmann/json.hpp>
 
+#include <inttypes.h>
+
 namespace falcosecurity
 {
 namespace _internal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

By wrapping C includes in a namespace declaration, we make it so that any libc headers will also belong to the resulting C namespace.  In the case of `inttypes.h`, this creates problems in the user's code when depending on declarations like `imaxdiv_t` to be in the global namespace and not `falcosecurity::_internal`. This problem is also compounded when combining the SDK with libraries with their own header files.

This PR simply adds a line to `deps.h` to ensure that `inttypes.h` is included before a namespace is opened.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
