### PR TITLE
fix(extract): always return a pointer to the first element of the vector

### DIFF
--- a/include/falcosecurity/extract_request.h
+++ b/include/falcosecurity/extract_request.h
@@ -179,10 +179,16 @@ class extract_request
     FALCOSECURITY_INLINE
     void set_value(bool v, size_t pos, bool copy)
     {
+        // The resize always ensure we have enough space in our vectors for 
+        // data we have to copy.
         resize_result(pos);
         auto r = reinterpret_cast<_internal::ss_plugin_bool*>(m_result.data());
+        // Please note that every element of `m_result` is on at least 8 bytes (see union result).
+        // Here we are casting it to a vector of `uint32_t` so we are writing an element every 4 bytes.
         r[pos] = (_internal::ss_plugin_bool)(v ? 1 : 0);
-        m_req->res.boolean = &r[pos];
+        // `m_req` contains the pointer to the `ss_plugin_extract_field` array obtained
+        // from the framework. The sdk always returns a pointer to an internal array.
+        m_req->res.boolean = &r[0];
         m_req->res_len = pos + 1;
     }
 
@@ -192,7 +198,7 @@ class extract_request
         resize_result(pos);
         auto r = reinterpret_cast<uint64_t*>(m_result.data());
         r[pos] = v;
-        m_req->res.u64 = &r[pos];
+        m_req->res.u64 = &r[0];
         m_req->res_len = pos + 1;
     }
 
@@ -210,7 +216,7 @@ class extract_request
         {
             r[pos] = v;
         }
-        m_req->res.str = &r[pos];
+        m_req->res.str = &r[0];
         m_req->res_len = pos + 1;
     }
 
@@ -235,7 +241,7 @@ class extract_request
             r[pos].ptr = buf;
             r[pos].len = (uint32_t)bufsize;
         }
-        m_req->res.buf = &r[pos];
+        m_req->res.buf = &r[0];
         m_req->res_len = pos + 1;
     }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

This PR ensures that we always return a pointer to the first element of the array and not to the current element. Without these changes the code segafults when we use the `set_value` method with a list, so filterchecks with the `EPF_IS_LIST` flag.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
