### PR TITLE
fix: release table_entry with the move operator and add default constructor for table_entry

### DIFF
--- a/include/falcosecurity/table.h
+++ b/include/falcosecurity/table.h
@@ -160,6 +160,8 @@ class table_entry
 {
     public:
     FALCOSECURITY_INLINE
+    table_entry() { m_entry = nullptr; };
+    FALCOSECURITY_INLINE
     table_entry(table_entry&& o)
     {
         m_entry = o.m_entry;
@@ -182,10 +184,7 @@ class table_entry
     FALCOSECURITY_INLINE
     table_entry& operator=(const table_entry&) = delete;
     FALCOSECURITY_INLINE
-    ~table_entry()
-    {
-        release_entry();
-    }
+    ~table_entry() { release_entry(); }
 
     FALCOSECURITY_INLINE
     table_entry(_internal::ss_plugin_table_entry_t* e,
@@ -203,7 +202,6 @@ class table_entry
     }
 
     private:
-
     FALCOSECURITY_INLINE
     void release_entry()
     {

--- a/include/falcosecurity/table.h
+++ b/include/falcosecurity/table.h
@@ -170,6 +170,7 @@ class table_entry
     FALCOSECURITY_INLINE
     table_entry& operator=(table_entry&& o)
     {
+        release_entry();
         m_entry = o.m_entry;
         m_table = o.m_table;
         m_reader = o.m_reader;
@@ -183,10 +184,7 @@ class table_entry
     FALCOSECURITY_INLINE
     ~table_entry()
     {
-        if(m_entry && m_reader->m_reader)
-        {
-            m_reader->m_reader->release_table_entry(m_table, m_entry);
-        }
+        release_entry();
     }
 
     FALCOSECURITY_INLINE
@@ -205,6 +203,16 @@ class table_entry
     }
 
     private:
+
+    FALCOSECURITY_INLINE
+    void release_entry()
+    {
+        if(m_entry && m_reader->m_reader)
+        {
+            m_reader->m_reader->release_table_entry(m_table, m_entry);
+        }
+    }
+
     _internal::ss_plugin_table_entry_t* m_entry;
     _internal::ss_plugin_table_t* m_table;
     const table_reader* m_reader;

--- a/include/falcosecurity/table.h
+++ b/include/falcosecurity/table.h
@@ -208,6 +208,7 @@ class table_entry
         if(m_entry && m_reader->m_reader)
         {
             m_reader->m_reader->release_table_entry(m_table, m_entry);
+            m_entry = nullptr;
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The `table_entry` class was missing the default constructor.
The `table_entry` move operator didn't clean up the left hand side `table_entry` when moving

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note

```
