### PR TITLE
update(build): bump libs to 0.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CURL ?= curl
 PATCH ?= patch
 CLANG_FORMAT ?= clang-format
 
-FALCOSECURITY_LIBS_REVISION ?= bb27230c08578ac504af816b51c20d659cb9e16a
+FALCOSECURITY_LIBS_REVISION ?= 0.20.0
 FALCOSECURITY_LIBS_REPO     ?= falcosecurity/libs
 DEPS_INCLUDEDIR             := include/falcosecurity/internal/deps
 DEPS_PLUGIN_LIB_URL         := https://raw.githubusercontent.com/${FALCOSECURITY_LIBS_REPO}/${FALCOSECURITY_LIBS_REVISION}/userspace/plugin


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR bumps libs to 0.20.0 so that it will appear in the release notes for the next plugin-sdk-cpp version.
Keeping it as wip until libs 0.20.0 will be released; i opened this one to keep me from forgetting :D 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
