### PR TITLE
fix(include/falcosecurity): fixed clang build issue.

### DIFF
--- a/include/falcosecurity/internal/plugin_mixin_async.h
+++ b/include/falcosecurity/internal/plugin_mixin_async.h
@@ -142,8 +142,7 @@ template<class Plugin, class Base> class plugin_mixin_async : public Base
                             const ss_plugin_async_event_handler_t h)
     {
         FALCOSECURITY_CATCH_ALL(Base::m_last_err_storage, {
-            auto handler = std::make_unique<async_event_handler>(o, h);
-            _dump_state(std::move(handler), static_cast<Plugin*>(this));
+            _dump_state(o, h, static_cast<Plugin*>(this));
             return SS_PLUGIN_SUCCESS;
         });
         return SS_PLUGIN_FAILURE;
@@ -183,8 +182,10 @@ template<class Plugin, class Base> class plugin_mixin_async : public Base
 
     template<typename T>
     FALCOSECURITY_INLINE auto
-    _dump_state(std::unique_ptr<falcosecurity::async_event_handler> h, T* o)
-            -> decltype(o->dump_state(std::move(h)))
+    _dump_state(ss_plugin_owner_t* owner,
+                const ss_plugin_async_event_handler_t h, T* o)
+            -> decltype(o->dump_state(std::make_unique<async_event_handler>(o,
+                                                                            h)))
     {
         static_assert(
                 std::is_same<void (T::*)(std::unique_ptr<
@@ -194,7 +195,7 @@ template<class Plugin, class Base> class plugin_mixin_async : public Base
                 "dump_state(std::unique_ptr<falcosecurity::async_event_handler>"
                 ")");
 
-        o->dump_state(std::move(h));
+        o->dump_state(std::make_unique<async_event_handler>(o, h));
     }
 
     FALCOSECURITY_INLINE


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area plugin-sdk

**What this PR does / why we need it**:

Fixes build issue with clang (discovered on osx):
```
In file included from /Users/runner/work/container_plugin/container_plugin/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/sdk.h:21:
In file included from /Users/runner/work/container_plugin/container_plugin/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/internal/symbols_async.h:21:
In file included from /Users/runner/work/container_plugin/container_plugin/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/internal/plugin_mixin.h:21:
/Users/runner/work/container_plugin/container_plugin/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/internal/plugin_mixin_async.h:146:25: error: cannot pass object of non-trivial type '__libcpp_remove_reference_t<unique_ptr<async_event_handler, default_delete<async_event_handler>> &>' (aka 'std::unique_ptr<falcosecurity::async_event_handler>') through variadic method; call will abort at runtime [-Wnon-pod-varargs]
            _dump_state(std::move(handler), static_cast<Plugin*>(this));
                        ^
/Users/runner/work/container_plugin/container_plugin/src/caps/async/async.cpp:99:1: note: in instantiation of member function 'falcosecurity::_internal::plugin_mixin_async<my_plugin, falcosecurity::_internal::plugin_mixin_capture_listening<my_plugin, falcosecurity::_internal::plugin_mixin_common<my_plugin>>>::dump_state' requested here
FALCOSECURITY_PLUGIN_ASYNC_EVENTS(my_plugin);
^
/Users/runner/work/container_plugin/container_plugin/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/internal/symbols_async.h:57:19: note: expanded from macro 'FALCOSECURITY_PLUGIN_ASYNC_EVENTS'
        return p->dump_state(o, h);                                            \
                  ^
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```

/hold