### PR TITLE
fix(include): fixed build warnings.

### DIFF
--- a/include/falcosecurity/inputs.h
+++ b/include/falcosecurity/inputs.h
@@ -323,11 +323,11 @@ class capture_listen_input
     FALCOSECURITY_INLINE
     capture_listen_input(capture_listen_input&&) = default;
     FALCOSECURITY_INLINE
-    capture_listen_input& operator=(capture_listen_input&&) = default;
+    capture_listen_input& operator=(capture_listen_input&&) = delete;
     FALCOSECURITY_INLINE
     capture_listen_input(const capture_listen_input&) = default;
     FALCOSECURITY_INLINE
-    capture_listen_input& operator=(const capture_listen_input&) = default;
+    capture_listen_input& operator=(const capture_listen_input&) = delete;
 
     FALCOSECURITY_INLINE
     const falcosecurity::table_reader& get_table_reader() const


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Fixes a couple of build warnings i found with clang:
```
/home/federico/Work/container/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/inputs.h:326:27: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  326 |     capture_listen_input& operator=(capture_listen_input&&) = default;
      |                           ^
/home/federico/Work/container/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/inputs.h:346:40: note: move assignment operator of 'capture_listen_input' is implicitly deleted because field 'm_table_reader' is of reference type 'const falcosecurity::table_reader &'
  346 |     const falcosecurity::table_reader& m_table_reader;
      |                                        ^
/home/federico/Work/container/build/_deps/plugin-sdk-cpp-src/include/falcosecurity/inputs.h:326:63: note: replace 'default' with 'delete'
  326 |     capture_listen_input& operator=(capture_listen_input&&) = default;
      |                                                               ^~~~~~~
      |                                                               delete
```

**Which issue(s) this PR fixes**:



Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
