### PR TITLE
fix: support vector of bytes in extract requests

### DIFF
--- a/include/falcosecurity/extract_request.h
+++ b/include/falcosecurity/extract_request.h
@@ -79,6 +79,17 @@ class extract_request
     FALCOSECURITY_INLINE
     bool is_list() const { return m_req->flist != 0; }
 
+    template<typename T>
+    FALCOSECURITY_INLINE auto set_value(const T& container, size_t pos = 0,
+                                        bool copy = true)
+            -> decltype(container.data(), container.size(), void())
+    {
+        static_assert(sizeof(typename T::value_type) == 1,
+                      "Buffer container must hold byte-sized elements");
+        set_value((void*)container.data(), (uint32_t)container.size(), pos,
+                  copy);
+    }
+
     template<typename Iter>
     FALCOSECURITY_INLINE void set_value(Iter begin, Iter end, bool copy = true)
     {

--- a/include/falcosecurity/types.h
+++ b/include/falcosecurity/types.h
@@ -134,6 +134,8 @@ struct field_arg
     FALCOSECURITY_INLINE
     field_arg() = default;
     FALCOSECURITY_INLINE
+    field_arg(bool k, bool i, bool r): key(k), index(i), required(r) {}
+    FALCOSECURITY_INLINE
     field_arg(field_arg&&) = default;
     FALCOSECURITY_INLINE
     field_arg& operator=(field_arg&&) = default;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area plugin-sdk

> /area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

At the moment we lack of an api to push vectors of bytebufs (e.g. a list of PT_IPADDR). This fixes it. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: update plugins to use new sdk version`.
-->

```release-note
NONE
```
