### PR TITLE
fix: extract_request set_value

### DIFF
--- a/include/falcosecurity/extract_request.h
+++ b/include/falcosecurity/extract_request.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <falcosecurity/types.h>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace falcosecurity
@@ -79,10 +80,15 @@ class extract_request
     FALCOSECURITY_INLINE
     bool is_list() const { return m_req->flist != 0; }
 
+    // Keep std::string out of this byte-buffer overload.
+    // Avoids set_value(std::string&) to be matched by this.
     template<typename T>
     FALCOSECURITY_INLINE auto set_value(T& container, size_t pos = 0,
-                                        bool copy = true)
-            -> decltype(container.data(), container.size(), void())
+                                        bool copy = true) ->
+            typename std::enable_if<!std::is_same<typename std::decay<T>::type,
+                                                  std::string>::value,
+                                    decltype(container.data(), container.size(),
+                                             void())>::type
     {
         static_assert(sizeof(typename T::value_type) == 1,
                       "Buffer container must hold byte-sized elements");


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area plugin-sdk

**What this PR does / why we need it**:
Exclude `std::string` from the generic byte-buffer `set_value()` overload.
Without this, non-const strings bind to `T&` and get exported as
`ss_plugin_byte_buffer` instead of string results.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
